### PR TITLE
Save ui_update in state store for persistency over page refresh

### DIFF
--- a/nodes/ui-edgewise-meter.js
+++ b/nodes/ui-edgewise-meter.js
@@ -28,9 +28,10 @@ module.exports = function (RED) {
                 // does msg.ui_update exist and is an object?
                 if (typeof msg.ui_update === 'object' && !Array.isArray(msg.ui_update) && msg.ui_update !== null) {
                     // yes it does
-                    storedData.ui_update ??= {}    // initialise if necessary
-                    // merge in data from this message
-                    storedData.ui_update = {...storedData.ui_update, ...msg.ui_update}
+                    // merge ui_update data from this message into the state store
+                    for (const [key, value] of Object.entries(msg.ui_update)) {
+                        base.stores.state.set(base, node, msg, key, value)
+                    }
                 } else {
                     // delete any msg.ui_update so don't need to validate in clients
                     delete msg.ui_update


### PR DESCRIPTION
Save ui_update data in state store so that updated values are automatically provided to the browser if the page is refreshed.

Fixes #3